### PR TITLE
Fix output to avoid parsing format specifiers

### DIFF
--- a/cmd/prettytest/main.go
+++ b/cmd/prettytest/main.go
@@ -51,6 +51,6 @@ func main() {
 			color = yellow
 		}
 
-		fmt.Fprintf(os.Stderr, color+line+"\033[0m\n")
+		fmt.Fprintln(os.Stderr, color+line+"\033[0m")
 	}
 }


### PR DESCRIPTION
If the input comes from `go test -cover`, it includes the coverage percentage. The final `fmt.Fprintf` was attempting to parse the `%` char in the string as a format specifier, producing:

```
ok  	github.com/martinrue/cosmo/config	(cached)	coverage: 100.0%!o(MISSING)f statements
```

Switching to `fmt.Fprintln` and removing the final `\n`, it now ignores `%` chars in the input, producing the expected output:

```
ok  	github.com/martinrue/cosmo/config	(cached)	coverage: 100.0% of statements
```